### PR TITLE
Api changes

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -20,7 +20,7 @@ type TrieNode struct {
 	// Some thought was put into alignment here. The following three fields fit
 	// within an 8-byte required alignment on x86_64 at least
 	size     uint32
-	height   uint16
+	h        uint16
 	active   bool
 	children [2]*TrieNode
 }
@@ -244,12 +244,12 @@ func (me *TrieNode) Size() int {
 	return int(me.size)
 }
 
-// Height returns the maximum height of the trie.
-func (me *TrieNode) Height() int {
+// height returns the maximum height of the trie.
+func (me *TrieNode) height() int {
 	if me == nil {
 		return 0
 	}
-	return int(me.height)
+	return int(me.h)
 }
 
 func intMax(a, b int) int {
@@ -271,10 +271,10 @@ func (me *TrieNode) insert(node *TrieNode, prematchedBits uint) (newHead *TrieNo
 	defer func() {
 		if err == nil && newHead != nil {
 			node.size = 1
-			node.height = 1
+			node.h = 1
 			node.active = true
 			newHead.size = uint32(newHead.children[0].Size() + newHead.children[1].Size())
-			newHead.height = 1 + uint16(uint16(intMax(newHead.children[0].Height(), newHead.children[1].Height())))
+			newHead.h = 1 + uint16(uint16(intMax(newHead.children[0].height(), newHead.children[1].height())))
 			if newHead.active {
 				newHead.size++
 			}
@@ -358,7 +358,7 @@ func (me *TrieNode) del(key *TrieKey, prematchedBits uint) (newHead *TrieNode, e
 	defer func() {
 		if err == nil && newHead != nil {
 			newHead.size = uint32(newHead.children[0].Size() + newHead.children[1].Size())
-			newHead.height = 1 + uint16(uint16(intMax(newHead.children[0].Height(), newHead.children[1].Height())))
+			newHead.h = 1 + uint16(uint16(intMax(newHead.children[0].height(), newHead.children[1].height())))
 			if newHead.active {
 				newHead.size++
 			}

--- a/trie.go
+++ b/trie.go
@@ -260,8 +260,11 @@ func intMax(a, b int) int {
 }
 
 // Insert is the public form of insert(...)
-func (me *TrieNode) Insert(node *TrieNode) (newHead *TrieNode, err error) {
-	return me.insert(node, 0)
+func (me *TrieNode) Insert(key *TrieKey, data interface{}) (newHead *TrieNode, err error) {
+	if key == nil {
+		return nil, fmt.Errorf("cannot insert nil key")
+	}
+	return me.insert(&TrieNode{TrieKey: *key, Data: data}, 0)
 }
 
 // insert adds a node into the trie and return the new root of the trie. It is
@@ -280,14 +283,6 @@ func (me *TrieNode) insert(node *TrieNode, prematchedBits uint) (newHead *TrieNo
 			}
 		}
 	}()
-
-	if node == nil {
-		return me, fmt.Errorf("cannot insert nil node")
-	}
-
-	if node.children[0] != nil || node.children[1] != nil {
-		return me, fmt.Errorf("cannot insert node with children")
-	}
 
 	if me == nil {
 		return node, nil

--- a/trie_test.go
+++ b/trie_test.go
@@ -77,7 +77,7 @@ func TestInsertNilNode(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, trie, newTrie)
 	assert.Equal(t, 0, trie.Size())
-	assert.Equal(t, 0, trie.Height())
+	assert.Equal(t, 0, trie.height())
 }
 
 func TestMatchNilTrie(t *testing.T) {
@@ -101,7 +101,7 @@ func TestInsertNodeWithChildren(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, trie, newTrie)
 	assert.Equal(t, 0, trie.Size())
-	assert.Equal(t, 0, trie.Height())
+	assert.Equal(t, 0, trie.height())
 
 	newTrie, err = trie.Insert(&TrieNode{
 		TrieKey:  key,
@@ -110,12 +110,12 @@ func TestInsertNodeWithChildren(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, trie, newTrie)
 	assert.Equal(t, 0, trie.Size())
-	assert.Equal(t, 0, trie.Height())
+	assert.Equal(t, 0, trie.height())
 
 	trie, err = trie.Insert(&TrieNode{TrieKey: key})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, trie.Size())
-	assert.Equal(t, 1, trie.Height())
+	assert.Equal(t, 1, trie.height())
 }
 
 func TestMatchZeroLength(t *testing.T) {
@@ -128,7 +128,7 @@ func TestMatchZeroLength(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, trie.active)
 	assert.Equal(t, 1, trie.Size())
-	assert.Equal(t, 1, trie.Height())
+	assert.Equal(t, 1, trie.height())
 
 	assert.Equal(t, trie, trie.Match(&TrieKey{
 		0,
@@ -146,7 +146,7 @@ func TestNoMatchTooBroad(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, trie.active)
 	assert.Equal(t, 1, trie.Size())
-	assert.Equal(t, 1, trie.Height())
+	assert.Equal(t, 1, trie.height())
 
 	assert.Nil(t, trie.Match(&TrieKey{
 		23,
@@ -217,7 +217,7 @@ func TestNoMatchPrefixMisMatch(t *testing.T) {
 			assert.Nil(t, err)
 			assert.True(t, trie.active)
 			assert.Equal(t, 1, trie.Size())
-			assert.Equal(t, 1, trie.Height())
+			assert.Equal(t, 1, trie.height())
 
 			assert.Nil(t, trie.Match(&TrieKey{
 				tt.searchLength,
@@ -277,7 +277,7 @@ func TestMatchSimplePrefixMatch(t *testing.T) {
 			trie, err := trie.Insert(node)
 			assert.Nil(t, err)
 			assert.Equal(t, 1, trie.Size())
-			assert.Equal(t, 1, trie.Height())
+			assert.Equal(t, 1, trie.height())
 			assert.True(t, node.active)
 
 			assert := assert.New(t)
@@ -338,7 +338,7 @@ func TestMatchPartialByteMatches(t *testing.T) {
 			assert.Nil(t, err)
 			assert.True(t, node.active)
 			assert.Equal(t, 1, trie.Size())
-			assert.Equal(t, 1, trie.Height())
+			assert.Equal(t, 1, trie.height())
 
 			assert := assert.New(t)
 			assert.Equal(trie, node)
@@ -400,21 +400,21 @@ func TestInsertOverlapping(t *testing.T) {
 					assert.Equal(t, trie, first)
 					assert.Equal(t, first, trie.Match(&first.TrieKey))
 					assert.Equal(t, 1, trie.Size())
-					assert.Equal(t, 1, trie.Height())
+					assert.Equal(t, 1, trie.height())
 
 					trie, err = trie.Insert(second)
 					assert.Nil(t, err)
 					assert.True(t, second.active)
 					assert.Equal(t, second, trie.Match(&second.TrieKey))
 					assert.Equal(t, 2, trie.Size())
-					assert.Equal(t, 2, trie.Height())
+					assert.Equal(t, 2, trie.height())
 
 					trie, err = trie.Insert(third)
 					assert.Nil(t, err)
 					assert.True(t, third.active)
 					assert.Equal(t, third, trie.Match(&third.TrieKey))
 					assert.Equal(t, 3, trie.Size())
-					assert.Equal(t, 3, trie.Height())
+					assert.Equal(t, 3, trie.height())
 				}
 			}
 			t.Run("forward", subTest(&TrieNode{TrieKey: tt.a}, &TrieNode{TrieKey: tt.b}, &TrieNode{TrieKey: tt.c}))
@@ -430,7 +430,7 @@ func TestInsertOverlapping(t *testing.T) {
 					assert.True(t, trie.active)
 					assert.NotNil(t, trie)
 					assert.Equal(t, 1, trie.Size())
-					assert.Equal(t, 1, trie.Height())
+					assert.Equal(t, 1, trie.height())
 
 					dup := &TrieNode{TrieKey: key}
 					newTrie, err := trie.Insert(dup)
@@ -438,7 +438,7 @@ func TestInsertOverlapping(t *testing.T) {
 					assert.False(t, dup.active)
 					assert.Equal(t, trie, newTrie)
 					assert.Equal(t, 1, trie.Size())
-					assert.Equal(t, 1, trie.Height())
+					assert.Equal(t, 1, trie.height())
 				}
 			}
 			t.Run("duplicate a", insertDuplicate(tt.a))
@@ -485,14 +485,14 @@ func TestInsertDisjoint(t *testing.T) {
 					assert.True(t, first.active)
 					assert.Equal(t, trie, first)
 					assert.Equal(t, 1, trie.Size())
-					assert.Equal(t, 1, trie.Height())
+					assert.Equal(t, 1, trie.height())
 
 					trie, err = trie.Insert(second)
 					assert.Nil(t, err)
 					assert.True(t, second.active)
 					assert.Equal(t, second, trie.Match(&second.TrieKey))
 					assert.Equal(t, 2, trie.Size())
-					assert.Equal(t, 2, trie.Height())
+					assert.Equal(t, 2, trie.height())
 
 					assert.Nil(t, trie.Match(&tt.super))
 
@@ -508,7 +508,7 @@ func TestInsertDisjoint(t *testing.T) {
 					assert.True(t, super.active)
 					assert.NotNil(t, trie.Match(&tt.super))
 					assert.Equal(t, 3, trie.Size())
-					assert.Equal(t, 2, trie.Height())
+					assert.Equal(t, 2, trie.height())
 				}
 			}
 			t.Run("forward", subTest(&TrieNode{TrieKey: tt.a}, &TrieNode{TrieKey: tt.b}))
@@ -1044,7 +1044,7 @@ func TestSuccessivelyBetter(t *testing.T) {
 		trie, err = trie.Insert(&TrieNode{TrieKey: key})
 		assert.Nil(t, err)
 		assert.Equal(t, index+1, trie.Size())
-		assert.Equal(t, index+1, trie.Height())
+		assert.Equal(t, index+1, trie.height())
 
 		for i, searchKey := range keys {
 			node := trie.Match(&searchKey)
@@ -1064,7 +1064,7 @@ func TestSuccessivelyBetter(t *testing.T) {
 		trie, err = trie.Delete(&key)
 		assert.Nil(t, err)
 		assert.Equal(t, len(keys)-index-1, trie.Size())
-		assert.Equal(t, len(keys)-index-1, trie.Height())
+		assert.Equal(t, len(keys)-index-1, trie.height())
 
 		for i, searchKey := range keys {
 			node := trie.Match(&searchKey)

--- a/trie_test.go
+++ b/trie_test.go
@@ -18,9 +18,9 @@ func minInt(a, b int) int {
 
 func TestActive(t *testing.T) {
 	var node *TrieNode
-	assert.False(t, node.Active())
-	assert.False(t, (&TrieNode{}).Active())
-	assert.True(t, (&TrieNode{active: true}).Active())
+	assert.False(t, node.active())
+	assert.False(t, (&TrieNode{}).active())
+	assert.True(t, (&TrieNode{isActive: true}).active())
 }
 
 func TestStructSizes(t *testing.T) {
@@ -126,7 +126,7 @@ func TestMatchZeroLength(t *testing.T) {
 		[]byte{},
 	}})
 	assert.Nil(t, err)
-	assert.True(t, trie.active)
+	assert.True(t, trie.active())
 	assert.Equal(t, 1, trie.Size())
 	assert.Equal(t, 1, trie.height())
 
@@ -144,7 +144,7 @@ func TestNoMatchTooBroad(t *testing.T) {
 		[]byte{10, 0, 0, 0},
 	}})
 	assert.Nil(t, err)
-	assert.True(t, trie.active)
+	assert.True(t, trie.active())
 	assert.Equal(t, 1, trie.Size())
 	assert.Equal(t, 1, trie.height())
 
@@ -215,7 +215,7 @@ func TestNoMatchPrefixMisMatch(t *testing.T) {
 				tt.nodePrefix,
 			}})
 			assert.Nil(t, err)
-			assert.True(t, trie.active)
+			assert.True(t, trie.active())
 			assert.Equal(t, 1, trie.Size())
 			assert.Equal(t, 1, trie.height())
 
@@ -278,7 +278,7 @@ func TestMatchSimplePrefixMatch(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, 1, trie.Size())
 			assert.Equal(t, 1, trie.height())
-			assert.True(t, node.active)
+			assert.True(t, node.active())
 
 			assert := assert.New(t)
 			assert.Equal(trie, node)
@@ -336,7 +336,7 @@ func TestMatchPartialByteMatches(t *testing.T) {
 			}}
 			trie, err := trie.Insert(node)
 			assert.Nil(t, err)
-			assert.True(t, node.active)
+			assert.True(t, node.active())
 			assert.Equal(t, 1, trie.Size())
 			assert.Equal(t, 1, trie.height())
 
@@ -396,7 +396,7 @@ func TestInsertOverlapping(t *testing.T) {
 
 					trie, err := trie.Insert(first)
 					assert.Nil(t, err)
-					assert.True(t, first.active)
+					assert.True(t, first.active())
 					assert.Equal(t, trie, first)
 					assert.Equal(t, first, trie.Match(&first.TrieKey))
 					assert.Equal(t, 1, trie.Size())
@@ -404,14 +404,14 @@ func TestInsertOverlapping(t *testing.T) {
 
 					trie, err = trie.Insert(second)
 					assert.Nil(t, err)
-					assert.True(t, second.active)
+					assert.True(t, second.active())
 					assert.Equal(t, second, trie.Match(&second.TrieKey))
 					assert.Equal(t, 2, trie.Size())
 					assert.Equal(t, 2, trie.height())
 
 					trie, err = trie.Insert(third)
 					assert.Nil(t, err)
-					assert.True(t, third.active)
+					assert.True(t, third.active())
 					assert.Equal(t, third, trie.Match(&third.TrieKey))
 					assert.Equal(t, 3, trie.Size())
 					assert.Equal(t, 3, trie.height())
@@ -427,7 +427,7 @@ func TestInsertOverlapping(t *testing.T) {
 
 					trie, err := trie.Insert(&TrieNode{TrieKey: key})
 					assert.Nil(t, err)
-					assert.True(t, trie.active)
+					assert.True(t, trie.active())
 					assert.NotNil(t, trie)
 					assert.Equal(t, 1, trie.Size())
 					assert.Equal(t, 1, trie.height())
@@ -435,7 +435,7 @@ func TestInsertOverlapping(t *testing.T) {
 					dup := &TrieNode{TrieKey: key}
 					newTrie, err := trie.Insert(dup)
 					assert.NotNil(t, err)
-					assert.False(t, dup.active)
+					assert.False(t, dup.active())
 					assert.Equal(t, trie, newTrie)
 					assert.Equal(t, 1, trie.Size())
 					assert.Equal(t, 1, trie.height())
@@ -482,14 +482,14 @@ func TestInsertDisjoint(t *testing.T) {
 
 					trie, err := trie.Insert(first)
 					assert.Nil(t, err)
-					assert.True(t, first.active)
+					assert.True(t, first.active())
 					assert.Equal(t, trie, first)
 					assert.Equal(t, 1, trie.Size())
 					assert.Equal(t, 1, trie.height())
 
 					trie, err = trie.Insert(second)
 					assert.Nil(t, err)
-					assert.True(t, second.active)
+					assert.True(t, second.active())
 					assert.Equal(t, second, trie.Match(&second.TrieKey))
 					assert.Equal(t, 2, trie.Size())
 					assert.Equal(t, 2, trie.height())
@@ -498,14 +498,14 @@ func TestInsertDisjoint(t *testing.T) {
 
 					// The following are testing a bit more of the internals
 					// than I normally do.
-					assert.False(t, trie.active)
+					assert.False(t, trie.active())
 					assert.Equal(t, trie.TrieKey, tt.super)
 
 					// insert an active node the same as `super` to turn it active
 					super := &TrieNode{TrieKey: tt.super}
 					trie, err = trie.Insert(super)
 					assert.Nil(t, err)
-					assert.True(t, super.active)
+					assert.True(t, super.active())
 					assert.NotNil(t, trie.Match(&tt.super))
 					assert.Equal(t, 3, trie.Size())
 					assert.Equal(t, 2, trie.height())
@@ -550,7 +550,7 @@ func TestInsertMoreComplex(t *testing.T) {
 					node := &TrieNode{TrieKey: key}
 					trie, err = trie.Insert(node)
 					assert.Nil(t, err)
-					assert.True(t, node.active)
+					assert.True(t, node.active())
 					assert.Equal(t, node, trie.Match(&key))
 				}
 			})
@@ -564,7 +564,7 @@ func TestInsertMoreComplex(t *testing.T) {
 					node := &TrieNode{TrieKey: key}
 					trie, err = trie.Insert(node)
 					assert.Nil(t, err)
-					assert.True(t, node.active)
+					assert.True(t, node.active())
 					assert.Equal(t, node, trie.Match(&key))
 				}
 			})


### PR DESCRIPTION
Make Active() and Height() private so that they’re not exported from the package.

Also, change Insert(node) to be Insert(key, data). This came up when I thought about adding an Update method where passing a TrieNode didn't seem like the right thing. Then, to be symmetric with Insert, it didn't seem like it was right there either.